### PR TITLE
建议默认添加scss文件

### DIFF
--- a/cssrem.sublime-settings
+++ b/cssrem.sublime-settings
@@ -1,5 +1,5 @@
 {
     "px_to_rem": 40,
     "max_rem_fraction_length": 6,
-    "available_file_types": [".css", ".less", ".sass"]
+    "available_file_types": [".css", ".less", ".sass", ".scss"]
 }


### PR DESCRIPTION
现在一般用sass都是用scss后缀，用这个普遍性更好，不用经常修改User配置。
